### PR TITLE
Scope `jest/unbound-method` to TypeScript files only

### DIFF
--- a/eslint/jest.js
+++ b/eslint/jest.js
@@ -1,3 +1,5 @@
+const { TYPESCRIPT_FILES } = require('./constants');
+
 module.exports = {
   plugins: ['testing-library'],
   extends: [
@@ -7,9 +9,15 @@ module.exports = {
     'plugin:testing-library/react',
     require.resolve('./rules/jest'),
   ],
-  rules: {
-    // Prefer the Jest version of this rule.
-    '@typescript-eslint/unbound-method': 'off',
-    'jest/unbound-method': 'error',
-  },
+  overrides: [
+    // Prefer the Jest version of this rule. This silently fails when type
+    // information is not available.
+    {
+      files: TYPESCRIPT_FILES,
+      rules: {
+        '@typescript-eslint/unbound-method': 'off',
+        'jest/unbound-method': 'error',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
This fixes an issue where this rule throws an error when run outside of a TypeScript app.