### PR TITLE
Remove `[skip ci]` from release message

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -16,7 +16,7 @@ module.exports = {
       '@semantic-release/git',
       {
         // eslint-disable-next-line no-template-curly-in-string
-        message: 'release: ${nextRelease.version} [skip ci]',
+        message: 'release: ${nextRelease.version}',
       },
     ],
   ],


### PR DESCRIPTION
This means that if the head commit on `canary` is a release with `[skip-ci]`, the merge to `main` won't trigger a release.