### PR TITLE
docs: recommend installing as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ All of our configs are contained in one package, `@vercel/style-guide`. To insta
 
 ```sh
 # If you use npm
-npm i @vercel/style-guide
+npm i --save-dev @vercel/style-guide
 
 # If you use pmpm
-pnpm i @vercel/style-guide
+pnpm i --save-dev @vercel/style-guide
 
 # If you use Yarn
-yarn add @vercel/style-guide
+yarn add --dev @vercel/style-guide
 ```
 
 Some of our ESLint configs require peer dependencies. We'll note those


### PR DESCRIPTION
Hello! :wave:

While doing a PR for https://github.com/styfle/links-awakening.
I noticed that in the README, you're recommending to install `@vercel/style-guide` as a normal dependency, but it should be installed as a `devDependencies`.

This PR updates `README.md` to recommend installing `@vercel/style-guide` as `devDependencies`.