### PR TITLE
feat(eslint): sort testing mocks to top of file

### DIFF
--- a/eslint/rules/import.js
+++ b/eslint/rules/import.js
@@ -81,6 +81,14 @@ module.exports = {
           'index', // Relative index
         ],
         'newlines-between': 'never',
+        pathGroups: [
+          // Sort test mocks to the top of the file to ensure that they're in place when it runs
+          {
+            group: 'builtin',
+            pattern: './*.test.mocks',
+            position: 'before',
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
In our unit tests, we often have a `*.test.mocks` file containing the mocking that we're doing for a test. For example, we might do this:

```ts
export const query: Record<string, string | boolean> = {
  next: '/home',
};

export const router = {
  isReady: false,
  pathname: '/login',
  query,
  replace: jest.fn(),
  push: jest.fn(),
};
export const useRouter = jest.fn(() => router);

jest.doMock('next/router', () => ({
  useRouter,
  __esModule: true,
  default: router,
}));
```

These mocks must be the first thing imported in the test file or else they won't be in place when the test imports the actual component. 

If we don't import anything from the mocks file, then eslint is perfectly happy with the mock import being first. However, as in the example above, we might want to import `useRouter` so that we can change its return value in different tests. If we do, then eslint will warn that the import order is incorrect.

This PR fixes that issue by adding a `pathGroups` entry that captures `./*.test.mocks` imports and requires them to be before `builtin`, which is the first item in our `groups` property.