### PR TITLE
fix: update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@next/eslint-plugin-next": "^12.3.0",
-    "eslint": "^8.48.0",
-    "prettier": "^3.0.0",
-    "typescript": "^4.8.0"
+    "@next/eslint-plugin-next": ">=12.3.0 <14",
+    "eslint": ">=8.48.0 <9",
+    "prettier": ">=3.0.0 <4",
+    "typescript": ">=4.8.0 <6"
   },
   "peerDependenciesMeta": {
     "@next/eslint-plugin-next": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ dependencies:
     specifier: ^7.22.11
     version: 7.22.11(@babel/core@7.22.11)(eslint@8.48.0)
   '@next/eslint-plugin-next':
-    specifier: ^12.3.0
+    specifier: '>=12.3.0 <14'
     version: 12.3.4
   '@rushstack/eslint-patch':
     specifier: ^1.3.3


### PR DESCRIPTION
This was missed in yesterday's update, as noted by @joulev here:
https://github.com/vercel/style-guide/pull/68#issuecomment-1696920827

This is a non-breaking fix, as the upper-bounds limits are for current latest releases (only future releases would be impacted). As far as I can tell, `@next/eslint-plugin-next` had no breaking changes for v13.