### PR TITLE
feat(eslint): expand peer `@next/eslint-plugin-next` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@next/eslint-plugin-next": ">=12.3.0 <14",
+    "@next/eslint-plugin-next": ">=12.3.0 <15",
     "eslint": ">=8.48.0 <9",
     "prettier": ">=3.0.0 <4",
     "typescript": ">=4.8.0 <6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ dependencies:
     specifier: ^7.22.11
     version: 7.22.11(@babel/core@7.22.11)(eslint@8.48.0)
   '@next/eslint-plugin-next':
-    specifier: '>=12.3.0 <14'
+    specifier: '>=12.3.0 <15'
     version: 12.3.4
   '@rushstack/eslint-patch':
     specifier: ^1.3.3


### PR DESCRIPTION
Briefly tested by installing it with `--legacy-peer-deps`. Doesn't seem to have any big issues arisen.