### PR TITLE
fix(typescript): `es2023` is not valid

### DIFF
--- a/typescript/tsconfig.node18.json
+++ b/typescript/tsconfig.node18.json
@@ -4,7 +4,7 @@
   "display": "Vercel Node 18",
   "docs": "https://github.com/vercel/style-guide",
   "compilerOptions": {
-    "lib": ["esnext"],
+    "lib": ["es2023"],
     "module": "node16",
     "target": "esnext",
     "moduleResolution": "node16"

--- a/typescript/tsconfig.node18.json
+++ b/typescript/tsconfig.node18.json
@@ -4,9 +4,9 @@
   "display": "Vercel Node 18",
   "docs": "https://github.com/vercel/style-guide",
   "compilerOptions": {
-    "lib": ["es2023"],
+    "lib": ["esnext"],
     "module": "node16",
-    "target": "es2023",
+    "target": "esnext",
     "moduleResolution": "node16"
   }
 }

--- a/typescript/tsconfig.node18.json
+++ b/typescript/tsconfig.node18.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     "lib": ["es2023"],
     "module": "node16",
-    "target": "esnext",
+    "target": "es2022",
     "moduleResolution": "node16"
   }
 }

--- a/typescript/tsconfig.node20.json
+++ b/typescript/tsconfig.node20.json
@@ -6,7 +6,7 @@
   "compilerOptions": {
     "lib": ["es2023"],
     "module": "node16",
-    "target": "esnext",
+    "target": "es2022",
     "moduleResolution": "node16"
   }
 }

--- a/typescript/tsconfig.node20.json
+++ b/typescript/tsconfig.node20.json
@@ -4,9 +4,9 @@
   "display": "Vercel Node 20",
   "docs": "https://github.com/vercel/style-guide",
   "compilerOptions": {
-    "lib": ["es2023"],
+    "lib": ["esnext"],
     "module": "node16",
-    "target": "es2023",
+    "target": "esnext",
     "moduleResolution": "node16"
   }
 }

--- a/typescript/tsconfig.node20.json
+++ b/typescript/tsconfig.node20.json
@@ -4,7 +4,7 @@
   "display": "Vercel Node 20",
   "docs": "https://github.com/vercel/style-guide",
   "compilerOptions": {
-    "lib": ["esnext"],
+    "lib": ["es2023"],
     "module": "node16",
     "target": "esnext",
     "moduleResolution": "node16"


### PR DESCRIPTION
According to
- https://www.typescriptlang.org/tsconfig#lib, and
- https://www.typescriptlang.org/tsconfig#target

`es2023` is not a valid value for `lib` and `target`. I propose using `esnext` for now (which is equivalent to `es2023` in a sense) and keep monitoring the status, since once `es2023` is available, `esnext` is likely equivalent to `es2024` by that time.