### PR TITLE
feat(eslint): remove deprecated `no-return-await`

### DIFF
--- a/eslint/rules/best-practice.js
+++ b/eslint/rules/best-practice.js
@@ -163,12 +163,6 @@ module.exports = {
      */
     'no-return-assign': 'error',
     /**
-     * Disallows unnecessary `return await`.
-     *
-     * 🚫 Not fixable - https://eslint.org/docs/rules/no-return-await
-     */
-    'no-return-await': 'error',
-    /**
      * Disallow use of `javascript:` urls.
      *
      * 🚫 Not fixable - https://eslint.org/docs/rules/no-script-url


### PR DESCRIPTION
Closes #88

BREAKING CHANGE: `no-return-await` is deprecated and has been removed.