### PR TITLE
feat(eslint): remove `no-await-in-loop`

### DIFF
--- a/eslint/browser.js
+++ b/eslint/browser.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: require.resolve('./_base'),
+  extends: './_base',
   env: {
     browser: true,
   },

--- a/eslint/rules/possible-errors.js
+++ b/eslint/rules/possible-errors.js
@@ -1,12 +1,6 @@
 module.exports = {
   rules: {
     /**
-     * Disallow await inside of loops.
-     *
-     * 🚫 Not fixable - https://eslint.org/docs/rules/no-await-in-loop
-     */
-    'no-await-in-loop': 'error',
-    /**
      * Disallow the use of console.
      *
      * 🚫 Not fixable - https://eslint.org/docs/rules/no-console


### PR DESCRIPTION
Closes #63

BREAKING CHANGE: `no-await-in-loop` has been removed.